### PR TITLE
fix random anomaly generator

### DIFF
--- a/source/demo/send-messages.sh
+++ b/source/demo/send-messages.sh
@@ -46,7 +46,7 @@ for (( i = 1; i <= $ITERATIONS; i++)) {
   SOUND=$(( 100 + $RANDOM % 40 ))
 
   # 3% chance of throwing an anomalous temperature reading
-  if [ $(($RANDOM % 100)) -gt 97 ]
+  if [ $(($RANDOM % 100)) -ge 97 ]
   then
     echo "TEMPERATURE OUT OF RANGE"
     TEMP=$(($TEMP*6))


### PR DESCRIPTION
*Issue #, if available:* anomaly rate is firing at 2% instead of indicated 3%

*Description of changes:* $RANDOM % 100 returns values 0-99. for 3% anomaly rate, the condition needs greater than or equal to 97 instead of greater than 97


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
