### PR TITLE
Update to nodejs8.10

### DIFF
--- a/deployment/real-time-iot-device-monitoring-with-kinesis.yaml
+++ b/deployment/real-time-iot-device-monitoring-with-kinesis.yaml
@@ -1151,7 +1151,7 @@ Resources:
       Handler: index.handler
       MemorySize: 256
       Role: !GetAtt CustomResourceHelperRole.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Timeout: 300
 
   CustomResourceHelperRole:


### PR DESCRIPTION
Update Lamda to use nodejs8.10 as nodejs6.10 deprecated

*Issue #, if available:*

*Description of changes:*
Update NodeJs runtime from v nodejs6.10 to nodejs8.10 (as now deprecated)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
