### PR TITLE
Correct README to reflect build-s3-dist.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ sudo apt-get install install zip wget gawk sed -y
 
 ## Building Lambda Package
 ```bash
-./deployment/build-s3-dist.sh source-bucket-base-name solution-name solution-version
+cd deployment/
+./build-s3-dist.sh source-bucket-base-name solution-name solution-version
 ```
 source-bucket-base-name should be the base name for the S3 bucket location where the template will source the Lambda code from.
 The template will append '-[region_name]' to this value.
@@ -17,7 +18,7 @@ For example: ./build-s3-dist.sh solutions
 The template will then expect the source code to be located in the solutions-[region_name] bucket
 
 ## CF template and Lambda function
-Located in deployment/dist
+The CF Template is located in `deployment/global-s3-assets` directory. The Lambda function is located in `deployment/regional-s3-assets` directory.
 
 
 ***


### PR DESCRIPTION
Correct build-s3-dist.sh commands in the README.md file to match remarks in build-s3-dist.sh file, which are correct. The existing command in README.md fails from project's root directory. Correct the output directories to match the actual output locations from the build-s3-dist.sh script.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
