### PR TITLE
Update send-messages.sh

### DIFF
--- a/source/demo/send-messages.sh
+++ b/source/demo/send-messages.sh
@@ -59,7 +59,11 @@ for (( i = 1; i <= $ITERATIONS; i++)) {
   echo "humidity: $HUMIDITY"
   echo "sound: $SOUND"
 
-  aws iot-data publish --topic "$TOPIC" --payload "{\"id\":\"1\",\"device\":\"$DEVICE\",\"flow\":$FLOW,\"temp\":$TEMP,\"humidity\":$HUMIDITY,\"sound\":$SOUND}" --profile "$PROFILE" --region "$REGION"
+  payload="{\"id\":\"1\",\"device\":\"$DEVICE\",\"flow\":$FLOW,\"temp\":$TEMP,\"humidity\":$HUMIDITY,\"sound\":$SOUND}"
+  payload_encoded=`echo -n $payload | base64`
+
+  aws iot-data publish --topic "$TOPIC" --payload $payload_encoded --profile "$PROFILE" --region "$REGION"
+
 
   sleep $WAIT
 


### PR DESCRIPTION
The payloads were not being base64 encoded, thus messages were not published with the error:

Invalid base64: "{"id":"1","device":"P02","flow":60,"temp":22,"humidity":74,"sound":126}"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
